### PR TITLE
add author, licence and description (if missing) to asdf files

### DIFF
--- a/cl-sam-test.asd
+++ b/cl-sam-test.asd
@@ -18,6 +18,9 @@
 ;;;
 
 (defsystem cl-sam-test
+    :author "Keith James"
+    :licence "GPL v3"
+    :description "Test system of cl-sam."
     :depends-on (:cl-sam
                  (:version :lift "1.7.0")
                  (:version :deoxybyte-io "0.9.6"))

--- a/cl-sam.asd
+++ b/cl-sam.asd
@@ -26,6 +26,8 @@
     :version "0.16.0"
     :author "Keith James"
     :licence "GPL v3"
+    :description "Toolkit for manipulation of DNA sequence alignment data stored
+    in the Sequence Alignment/Map (SAM) format."
     :depends-on ((:version :deoxybyte-systems "1.0.0")
                  (:version :deoxybyte-gzip "0.6.0")
                  (:version :deoxybyte-unix "0.8.0"))


### PR DESCRIPTION
A trivial pull request to add a author, licence and description (if missing) to the system definition files (as asked by Xach [1]) to enable strict metadata checking in quicklisp.

[1] https://www.reddit.com/r/lisp/comments/37bxu7/systems_in_red_dont_build_if_strict_checking_of/
